### PR TITLE
メッセージの自動更新機能の追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -94,7 +94,7 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log('alert');
+      alert('error');
     })
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,7 @@
 $(function(){
-  function buildHTML(message){
-    if ( message.image ) {
+
+  var buildHTML = function(message) {
+    if (message.text && message.image) {
       var html = `<div class="list" data-message-id=${message.id}>
                     <div class="chat-list">
                       <div class="chat-list__name">
@@ -17,8 +18,7 @@ $(function(){
                       <img class="message-list__image" src=${message.image}>
                     </div>
                   </div>`
-      return html;
-    } else {
+    } else if (message.text) {
       var html = `<div class="list" data-message-id=${message.id}>
                     <div class="chat-list">
                       <div class="chat-list__name">
@@ -34,9 +34,23 @@ $(function(){
                       </p>
                     </div>
                   </div>`
-      return html;
+    }else if (message.image) {
+      var html = `<div class="list" data-message-id=${message.id}>
+                    <div class="chat-list">
+                      <div class="chat-list__name">
+                        ${message.user_name}
+                      </div>
+                      <div class="chat-list__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="message-list">
+                      <img class="message-list__image" src=${message.image}>
+                    </div>`
     };
-  }
+    return html;
+  };
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -59,5 +73,33 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
     });
-  })
+  });
+
+  var reloadMessages = function() {
+    last_message_id = $('.list:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+      $('.main-chat__message-list').append(insertHTML);
+      $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+      $("#new_message")[0].reset();
+      $(".submit-btn").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      console.log('error');
+    })
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -91,12 +91,10 @@ $(function(){
         });
       $('.main-chat__message-list').append(insertHTML);
       $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
-      $("#new_message")[0].reset();
-      $(".submit-btn").prop("disabled", false);
       }
     })
     .fail(function() {
-      console.log('error');
+      console.log('alert');
     })
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.list
+.list{data: {message: {id: message.id}}}
   .chat-list
     .chat-list__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,7 @@
+
+
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.text @message.text
 json.image @message.image_url
+json.id @message.id


### PR DESCRIPTION
# What
メッセージ画面の自動更新機能を追加。
WebAPIにて実装。
新規投稿メッセージのみをDBから取得し、json形式で投稿内容をレスポンス。
７秒ごとに自動更新。

https://i.gyazo.com/11badaea5309ab1a0bda78d548b68021.gif

# Why
別のユーザーの投稿メッセージをリロードせずに表示するため。
